### PR TITLE
Correct min/max typo

### DIFF
--- a/preprocessing/about_standardization_normalization.ipynb
+++ b/preprocessing/about_standardization_normalization.ipynb
@@ -515,7 +515,7 @@
       "print('Min-value after min-max scaling:\\nAlcohol={:.2f}, Malic acid={:.2f}'\n",
       "      .format(df_minmax[:,0].min(), df_minmax[:,1].min()))\n",
       "print('\\nMax-value after min-max scaling:\\nAlcohol={:.2f}, Malic acid={:.2f}'\n",
-      "      .format(df_minmax[:,0].max(), df_minmax[:,1].max()))"
+      "      .format(df_minmax[:,0].min(), df_minmax[:,1].max()))"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
Hi Sebastian,

Thank you for this set of articles. They're awesome. I found this one minor typo as I was working through the feature scaling article. Also, on your blog itself (but not in this iPython notebook), there seems to be some duplication. From 'The effect of standardization on PCA in a pattern classification task' onward, the content appears twice.

That is on this page: http://www.sebastianraschka.com/Articles/2014_about_feature_scaling.html#The-effect-of-standardization
